### PR TITLE
Fix cachegrab_gui issue

### DIFF
--- a/client/cachegrab/gui/dataset_explorer.py
+++ b/client/cachegrab/gui/dataset_explorer.py
@@ -53,7 +53,7 @@ class DatasetExplorer(wx.Panel):
         self.btn_del = wx.Button(self, wx.ID_ANY, "Delete")
         self.btn_act = wx.Button(self, wx.ID_ANY, "Activate")
 
-        grid = wx.GridSizer(3, 2)
+        grid = wx.GridSizer(3, 2, wx.Size(0,0))
         grid.AddMany([
             (self.btn_add, 0, wx.EXPAND),
             (self.btn_mv, 0, wx.EXPAND),


### PR DESCRIPTION
Installing the latest version of wxPython (4.0.4) yields the following error when executing `cachegrab_gui`:
```c
  File "/usr/local/lib/python2.7/dist-packages/cachegrab-0.1.0-py2.7.egg/cachegrab/gui/dataset_explorer.py", line 56, in __init__
    grid = wx.GridSizer(3, 2)
TypeError: GridSizer(): arguments did not match any overloaded call:
  overload 1: not enough arguments
  overload 2: argument 2 has unexpected type 'int'
  overload 3: not enough arguments
  overload 4: not enough arguments
```
Updating the call to include a third `gap` argument fixes this problem.
An alternative solution would be to specify in `requirements.txt` the specific version of wxPython which must be used.